### PR TITLE
Add LiveView collections index page

### DIFF
--- a/app/lib/flamingo_web/live/collection_live/index.ex
+++ b/app/lib/flamingo_web/live/collection_live/index.ex
@@ -1,0 +1,27 @@
+defmodule FlamingoWeb.CollectionLive.Index do
+  use Phoenix.LiveView
+  use FlamingoWeb
+
+  alias Flamingo.Collections
+
+  def mount(_params, _session, socket) do
+    collections = Collections.all_collections()
+    {:ok, assign(socket, :collections, collections)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.header>
+      Collections
+    </.header>
+    <.table id="collections" rows={@collections}>
+      <:col :let={collection} label="Name">
+        <%= collection.name %>
+      </:col>
+      <:col :let={collection} label="Description">
+        <%= collection.description %>
+      </:col>
+    </.table>
+    """
+  end
+end

--- a/app/lib/flamingo_web/live/collection_live/index.html.heex
+++ b/app/lib/flamingo_web/live/collection_live/index.html.heex
@@ -1,0 +1,11 @@
+<.header>
+  Collections
+</.header>
+<.table id="collections" rows={@collections}>
+  <:col :let={collection} label="Name">
+    <%= collection.name %>
+  </:col>
+  <:col :let={collection} label="Description">
+    <%= collection.description %>
+  </:col>
+</.table>

--- a/app/lib/flamingo_web/router.ex
+++ b/app/lib/flamingo_web/router.ex
@@ -1,6 +1,8 @@
 defmodule FlamingoWeb.Router do
   use FlamingoWeb, :router
 
+  import FlamingoWeb.CollectionLive.Index
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -18,6 +20,7 @@ defmodule FlamingoWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+    live "/collections", CollectionLive.Index, :index
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
Add a LiveView index page to display all collections.

* **Router Changes**
  - Add a new route for the collections index page in `app/lib/flamingo_web/router.ex`.
  - Import `FlamingoWeb.CollectionLive.Index` module.

* **LiveView Module**
  - Create `FlamingoWeb.CollectionLive.Index` module in `app/lib/flamingo_web/live/collection_live/index.ex`.
  - Define `mount/3` function to fetch collections and assign to socket.
  - Define `render/1` function to render the collections index template.

* **Template**
  - Add `app/lib/flamingo_web/live/collection_live/index.html.heex` template for the collections index page.
  - Use `FlamingoWeb.CoreComponents.table/1` to display collections in a table.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hl/flamingo/pull/1?shareId=755a8234-0e65-4fd9-92fc-35279f539db5).